### PR TITLE
Ensure the root element will be returned if the selector matches it.

### DIFF
--- a/ampersand-dom-bindings.js
+++ b/ampersand-dom-bindings.js
@@ -1,6 +1,7 @@
 var Store = require('key-tree-store');
 var isArray = require('is-array');
 var dom = require('ampersand-dom');
+var matchesSelector = require('matches-selector');
 
 
 // returns a key-tree-store of functions
@@ -36,6 +37,7 @@ var slice = Array.prototype.slice;
 
 function getMatches(el, selector, func) {
     if (selector === '') return [el];
+    if (matchesSelector(el, selector)) return [el];
     return slice.call(el.querySelectorAll(selector));
 }
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "ampersand-dom": "^1.2.0",
     "is-array": "^1.0.1",
-    "key-tree-store": "^1.2.0"
+    "key-tree-store": "^1.2.0",
+    "matches-selector": "^1.0.0"
   },
   "devDependencies": {
     "browserify": "",

--- a/test/index.js
+++ b/test/index.js
@@ -158,6 +158,27 @@ test('innerHTML bindings', function (t) {
     t.end();
 });
 
+test('ensure selector matches root element', function (t) {
+    var el = getEl();
+    var bindings = domBindings({
+        'model': {
+            type: 'innerHTML',
+            selector: 'div' //select the root element
+        }
+    });
+
+    t.notOk(el.innerHTML, 'should be empty to start');
+
+    bindings.run('', null, el, '<span></span>');
+    t.equal(el.innerHTML, '<span></span>', 'should hav a span now');
+
+    bindings.run('', null, el, '');
+    t.notOk(el.innerHTML, 'should be empty again');
+
+    t.end();
+
+});
+
 // TODO: tests for toggle
 
 // TODO: tests for switch


### PR DESCRIPTION
e.g.:

<div class='foo'></div>


should match `selector: '.foo'` as well as `selector: ''`

Fixes: #6
