### PR TITLE
fix booleanclass when using yes/no values

### DIFF
--- a/ampersand-dom-bindings.js
+++ b/ampersand-dom-bindings.js
@@ -88,9 +88,12 @@ function getBindingFunc(binding) {
         // if there's a `no` case this is actually a switch
         if (binding.no) {
             return function (el, value, keyName) {
-                var name = binding.name || binding.yes || keyName;
+                var yes = binding.name || binding.yes || keyName;
+                var no = binding.no;
                 getMatches(el, selector).forEach(function (match) {
-                    dom.switchClass(match, binding.no, name);
+                    var prevClass = value ? no : yes;
+                    var newClass = value ? yes : no;
+                    dom.switchClass(match, prevClass, newClass);
                 });
             };
         } else {

--- a/test/index.js
+++ b/test/index.js
@@ -150,6 +150,31 @@ test('booleanClass bindings', function (t) {
     t.end();
 });
 
+test('booleanClass yes/no bindings', function (t) {
+    var el = getEl('<input type="checkbox" class="thing" role="some-role">');
+    var bindings = domBindings({
+        'model': {
+            type: 'booleanClass',
+            selector: '.thing',
+            yes: 'awesome',
+            no: 'not-awesome'
+        }
+    });
+
+    t.notOk(dom.hasClass(el.firstChild, 'awesome'), 'should not start with yes class');
+    t.notOk(dom.hasClass(el.firstChild, 'not-awesome'), 'should not start with no class');
+
+    bindings.run('', null, el, true);
+    t.ok(dom.hasClass(el.firstChild, 'awesome'), 'should have yes class');
+    t.notOk(dom.hasClass(el.firstChild, 'not-awesome'), 'should not have no class');
+
+    bindings.run('', null, el, false);
+    t.notOk(dom.hasClass(el.firstChild, 'awesome'), 'should not have yes class');
+    t.ok(dom.hasClass(el.firstChild, 'not-awesome'), 'should have no class');
+
+    t.end();
+});
+
 test('booleanAttribute bindings', function (t) {
     var el = getEl('<input type="checkbox" class="thing" role="some-role">');
     var bindings = domBindings({


### PR DESCRIPTION
Fixes an issue reported by @jedireza in IRC.

Basically, when using `booleanClass` with `yes` and `no` values, the `no` value would never get added to the class list.
