### PR TITLE
Change to the selector query from = to ~=

### DIFF
--- a/ampersand-dom-bindings.js
+++ b/ampersand-dom-bindings.js
@@ -53,7 +53,7 @@ function getBindingFunc(binding) {
         if (typeof binding.selector === 'string') {
             return binding.selector;
         } else if (binding.hook) {
-            return '[data-hook="' + binding.hook + '"]';
+            return '[data-hook~="' + binding.hook + '"]';
         } else {
             return '';
         }


### PR DESCRIPTION
Shouldn't it be consistent with ampersand-view's queryByHook()?
