### PR TITLE
allow custom types to be created and run

### DIFF
--- a/ampersand-dom-bindings.js
+++ b/ampersand-dom-bindings.js
@@ -47,6 +47,7 @@ function makeArray(val) {
 
 function getBindingFunc(binding) {
     var type = binding.type || 'text';
+    var isCustomBinding = typeof type === 'function';
     var selector = (function () {
         if (typeof binding.selector === 'string') {
             return binding.selector;
@@ -60,7 +61,14 @@ function getBindingFunc(binding) {
     // storage variable for previous if relevant
     var previousValue;
 
-    if (type === 'text') {
+    if (isCustomBinding) {
+        return function (el, value) {
+            getMatches(el, selector).forEach(function (match) {
+                type(match, value, previousValue);
+            });
+            previousValue = value;
+        };
+    } else if (type === 'text') {
         return function (el, value) {
             getMatches(el, selector).forEach(function (match) {
                 dom.text(match, value);
@@ -173,13 +181,6 @@ function getBindingFunc(binding) {
                     });
                 });
             }
-        };
-    } else if (typeof type === 'function') {
-        return function (el, value) {
-            getMatches(el, selector).forEach(function (match) {
-                type(match, value, previousValue);
-            });
-            previousValue = value;
         };
     } else {
         throw new Error('no such binding type: ' + type);

--- a/test/index.js
+++ b/test/index.js
@@ -473,6 +473,29 @@ test('custom binding', function (t) {
     t.end();
 });
 
+//Bad type is an error
+test('Errors on a bad type', function (t) {
+    function bindings(type) {
+        return function () {
+            domBindings({
+                'model': {
+                    type: type,
+                    selector: '.thing'
+                }
+            });
+        };
+    }
+    function errMsg(msg) {
+        return new RegExp(('no such binding type: ' + msg).replace(/[\[\]]/g, '\\$&'));
+    }
+
+    t.throws(bindings('not-a-type'), errMsg('not-a-type'));
+    t.throws(bindings({}), errMsg({}));
+    t.throws(bindings([]), errMsg([]));
+
+    t.end();
+});
+
 // TODO: tests for toggle
 
 // TODO: tests for switch


### PR DESCRIPTION
The API for `ampersand-dom-bindings` would be:

``` js
domBindings({
  'model.key': {
    type: 'customType',
    selector: '.thing'
  }
}, {
  customType: function (el, value, previousValue) { /* ... */ }
})
```

The idea is that `ampersand-view` could have a `bindingTypes` hash that would get passed to `ampersand-dom-bindings` so that they could be used like this:

``` js
View.extend({
  bindings: {
    'model.name': {
        type: 'customNameValue',
        hook: 'name'
    }
  },
  bindingTypes: {
    customNameValue: function (el, value, previousValue) { /* ... */ }
  }
});
```

Closes #21
