### PR TITLE
implement switchAttribute binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,35 @@ Toggles existence of a class on multiple elements based on value of property.
 }
 ```
 
+### switchAttribute
+
+Sets attribute(s) on matching elements based on the value of a property matching the case.
+
+```js
+'model.key': {
+    type: 'switchAttribute',
+    selector: 'a', // or hook
+    name: 'href',  // name defaults to the property name (e.g. 'key' from 'model.key' in this example)
+    cases: {
+        value1: '/foo',
+        value2: '/bar'
+    }
+}
+```
+
+You can also specify multiple attributes by using an object as the case value. The object keys are used instead of the `name` option.
+
+```js
+'model.key': {
+    type: 'switchAttribute',
+    selector: 'a', // or hook
+    cases: {
+        value1: { href: '/foo', name: 'foo' },
+        value2: { href: '/bar', name: 'bar' }
+    }
+}
+```
+
 ### innerHTML
 
 renders innerHTML, can be a string or DOM, based on property value of model

--- a/ampersand-dom-bindings.js
+++ b/ampersand-dom-bindings.js
@@ -42,6 +42,18 @@ function getMatches(el, selector) {
     return matches.concat(slice.call(el.querySelectorAll(selector)));
 }
 
+function setAttributes(el, attrs) {
+    for (var name in attrs) {
+        dom.setAttribute(el, name, attrs[name]);
+    }
+}
+
+function removeAttributes(el, attrs) {
+    for (var name in attrs) {
+        dom.removeAttribute(el, name);
+    }
+}
+
 function makeArray(val) {
     return Array.isArray(val) ? val : [val];
 }
@@ -185,6 +197,26 @@ function getBindingFunc(binding, context) {
                     });
                 });
             }
+        };
+    } else if (type === 'switchAttribute') {
+        if (!binding.cases) throw Error('switchAttribute bindings must have "cases"');
+        return function (el, value, keyName) {
+            getMatches(el, selector).forEach(function (match) {
+                if (previousValue) {
+                    removeAttributes(match, previousValue);
+                }
+
+                if (value in binding.cases) {
+                    var attrs = binding.cases[value];
+                    if (typeof attrs === 'string') {
+                        attrs = {};
+                        attrs[binding.name || keyName] = binding.cases[value];
+                    }
+                    setAttributes(match, attrs);
+
+                    previousValue = attrs;
+                }
+            });
         };
     } else {
         throw new Error('no such binding type: ' + type);

--- a/test/index.js
+++ b/test/index.js
@@ -374,6 +374,125 @@ test('switchClass bindings', function (t) {
     t.end();
 });
 
+test('switchAttribute bindings using name option', function(t) {
+    var el = getEl('<div></div>');
+
+    var bindings = domBindings({
+        'model': {
+            type: 'switchAttribute',
+            selector: 'div',
+            name: 'type',
+            cases: {
+                foo: 'text',
+                bar: 'password',
+            }
+        }
+    });
+
+    t.strictEqual(dom.getAttribute(el, 'type'), null, 'el should not have the attribute "type"');
+
+    bindings.run('', null, el, 'foo');
+    t.equal(dom.getAttribute(el, 'type'), 'text');
+
+    bindings.run('', null, el, 'bar');
+    t.equal(dom.getAttribute(el, 'type'), 'password');
+
+    bindings.run('', null, el, 'abcdefg');
+    t.equal(dom.getAttribute(el, 'type'), null);
+
+    t.end();
+});
+
+test('switchAttribute bindings without name option', function(t) {
+    var el = getEl('<div></div>');
+
+    var bindings = domBindings({
+        'model.href': {
+            type: 'switchAttribute',
+            selector: 'div',
+            cases: {
+                foo: '/foo',
+                bar: '/bar',
+            }
+        }
+    });
+
+    t.strictEqual(dom.getAttribute(el, 'href'), null, 'el should not have the attribute "href"');
+
+    bindings.run('', null, el, 'foo', 'href');
+    t.equal(dom.getAttribute(el, 'href'), '/foo');
+
+    bindings.run('', null, el, 'bar', 'href');
+    t.equal(dom.getAttribute(el, 'href'), '/bar');
+
+    bindings.run('', null, el, 'abcdefg', 'href');
+    t.equal(dom.getAttribute(el, 'href'), null);
+
+    t.end();
+});
+
+test('switchAttribute bindings with multiple attributes', function(t) {
+    var el = getEl('<div></div>');
+
+    var bindings = domBindings({
+        'model': {
+            type: 'switchAttribute',
+            selector: 'div',
+            cases: {
+              foo: { href: '/one', name: 'one' },
+              bar: { href: '/two', name: 'two' },
+            }
+        }
+    });
+
+    t.strictEqual(dom.getAttribute(el, 'href'), null, 'el should not have the attribute "href"');
+    t.strictEqual(dom.getAttribute(el, 'name'), null, 'el should not have the attribute "name"');
+
+    bindings.run('', null, el, 'foo');
+    t.equal(dom.getAttribute(el, 'href'), '/one');
+    t.equal(dom.getAttribute(el, 'name'), 'one');
+
+    bindings.run('', null, el, 'bar');
+    t.equal(dom.getAttribute(el, 'href'), '/two');
+    t.equal(dom.getAttribute(el, 'name'), 'two');
+
+    bindings.run('', null, el, 'abcdefg');
+    t.equal(dom.getAttribute(el, 'href'), null);
+    t.equal(dom.getAttribute(el, 'name'), null);
+
+    t.end();
+});
+
+test('switchAttribute with boolean/undefined properties', function(t) {
+    var el = getEl();
+
+    var bindings = domBindings({
+        'model': {
+            type: 'switchAttribute',
+            selector: 'div',
+            name: 'style',
+            cases: {
+              true: 'display: block',
+              false: 'display: none',
+              undefined: 'color: gray',
+            }
+        }
+    });
+
+    t.strictEqual(dom.getAttribute(el, 'style'), null, 'el should not have the attribute "style"');
+
+    bindings.run('', null, el, true);
+    t.equal(dom.getAttribute(el, 'style'), 'display: block');
+
+    bindings.run('', null, el, false);
+    t.equal(dom.getAttribute(el, 'style'), 'display: none');
+
+    bindings.run('', null, el, undefined);
+    t.equal(dom.getAttribute(el, 'style'), 'color: gray');
+
+    t.end();
+});
+
 test('ensure selector matches root element', function (t) {
     var el = getEl();
     var bindings = domBindings({


### PR DESCRIPTION
Implements `switchAttribute` binding as described in https://github.com/AmpersandJS/ampersand-dom-bindings/issues/25

- supports using either a `name: "attribute name"` option, or providing a key/value object as the case value, where the keys become the attribute names to set
- different values can set different attributes safely - attributes set by the previous value are cleared
- If the value is not handled in one of the cases, the previously-set attributes are cleared