### PR TITLE
Remove obsolete dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "ampersand-dom": "^1.2.5",
     "ampersand-version": "^1.0.0",
-    "is-array": "^1.0.1",
     "key-tree-store": "^1.2.0",
     "lodash.partial": "^3.1.1",
     "matches-selector": "^1.0.0"


### PR DESCRIPTION
The is-array dependency has been replaced by lodash.isarray.