### PR TITLE
Added 'invert' option to boolean-like bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ add/removes class based on boolean interpretation of property name. `name`, `yes
 
 ### booleanAttribute
 
-toggles whole attribute on the element (think `checked`) based on boolean interpretation of property name. `name` can also be an array of attribute names where all the values will be toggled. If you need the opposite effect, (`false` adds class, `true` removes class), specify `invert: true`.
+toggles whole attribute on the element (think `checked`) based on boolean interpretation of property name. `name` can also be an array of attribute names where all the values will be toggled. If you need the opposite effect, (`false` adds attribute, `true` removes attribute), specify `invert: true`.
 
 ```js
 'model.isAwesome': {

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sets the value of the element to match value of the property. works well for `in
 
 ### booleanClass
 
-add/removes class based on boolean interpretation of property name. `name`, `yes`, or `no` can also be an array of class names where all the values will be toggled.
+add/removes class based on boolean interpretation of property name. `name`, `yes`, or `no` can also be an array of class names where all the values will be toggled. If you need the opposite effect, (`false` adds class, `true` removes class), specify `opposite: true`.
 
 ```js
 'model.active': {
@@ -80,6 +80,8 @@ add/removes class based on boolean interpretation of property name. `name`, `yes
     // or a yes/no case
     yes: 'active',
     no: 'not-active'
+    // if you need opposite interpretation
+    opposite: true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ toggles visibility (using display: none by default) of entire element based on b
     selector: '#something' // or hook
 }
 
-// Inverse interpretation of property
+// Inverse interpretation of value
 'model.key': {
     type: 'toggle',
     invert: true,

--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ toggles visibility (using display: none by default) of entire element based on b
     selector: '#something' // or hook
 }
 
+// Reverse/opposite interpretation of property
+'model.key': {
+    type: 'toggle',
+    opposite: true,
+    hook: 'some-element'
+}
+
 // toggle visibility property instead
 'model.key': {
     type: 'toggle',

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sets the value of the element to match value of the property. works well for `in
 
 ### booleanClass
 
-add/removes class based on boolean interpretation of property name. `name`, `yes`, or `no` can also be an array of class names where all the values will be toggled. If you need the opposite effect, (`false` adds class, `true` removes class), specify `opposite: true`.
+add/removes class based on boolean interpretation of property name. `name`, `yes`, or `no` can also be an array of class names where all the values will be toggled. If you need the opposite effect, (`false` adds class, `true` removes class), specify `invert: true`.
 
 ```js
 'model.active': {
@@ -80,14 +80,14 @@ add/removes class based on boolean interpretation of property name. `name`, `yes
     // or a yes/no case
     yes: 'active',
     no: 'not-active'
-    // if you need opposite interpretation
-    opposite: true
+    // if you need inverse interpretation
+    invert: true
 }
 ```
 
 ### booleanAttribute
 
-toggles whole attribute on the element (think `checked`) based on boolean interpretation of property name. `name` can also be an array of attribute names where all the values will be toggled. If you need the opposite effect, (`false` adds class, `true` removes class), specify `opposite: true`.
+toggles whole attribute on the element (think `checked`) based on boolean interpretation of property name. `name` can also be an array of attribute names where all the values will be toggled. If you need the opposite effect, (`false` adds class, `true` removes class), specify `invert: true`.
 
 ```js
 'model.isAwesome': {
@@ -99,8 +99,8 @@ toggles whole attribute on the element (think `checked`) based on boolean interp
     // or a yes/no case
     yes: 'data-is-awesome',
     no: 'data-is-not-awesome'
-    // if you need opposite interpretation
-    opposite: true
+    // if you need inverse interpretation
+    invert: true
 }
 ```
 
@@ -115,10 +115,10 @@ toggles visibility (using display: none by default) of entire element based on b
     selector: '#something' // or hook
 }
 
-// Reverse/opposite interpretation of property
+// Inverse interpretation of property
 'model.key': {
     type: 'toggle',
-    opposite: true,
+    invert: true,
     hook: 'some-element'
 }
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ sets and maintains single class as string that matches value of property
 }
 ```
 
-### attribute 
+### attribute
 sets the whole attribute to match value of property. treats `undefined`, `null`, and `NaN` as `''` (empty string). `name` can also be an array to set multiple attributes to the same value.
-    
+
 ```js
 'model.key': {
     type: 'attribute',
@@ -58,7 +58,7 @@ sets the whole attribute to match value of property. treats `undefined`, `null`,
 sets the value of the element to match value of the property. works well for `input`, `select`, and `textarea` elements. treats `undefined`, `null`, and `NaN` as `''` (empty string).
 
 **note**: The binding will only be applied if the element is not currently in focus. This is done by checking to see if the element is the `document.activeElement` first. The reason it works this way is because if you've set up two-way data bindings you get a circular event: the input changes, which sets the bound model property, which in turn updates the value of the input. This might sound OK but results in the cursor always jumping to the end of the input/textarea. So if you're editing the middle of a bound text field, the cursor keeps jumping to the end. We avoid this by making sure it's not already in focus thus avoiding the bad loop.
-    
+
 ```js
 'model.key': {
     type: 'value',
@@ -85,7 +85,7 @@ add/removes class based on boolean interpretation of property name. `name`, `yes
 
 ### booleanAttribute
 
-toggles whole attribute on the element (think `checked`) based on boolean interpretation of property name. `name` can also be an array of attribute names where all the values will be toggled.
+toggles whole attribute on the element (think `checked`) based on boolean interpretation of property name. `name` can also be an array of attribute names where all the values will be toggled. If you need the opposite effect, (`false` adds class, `true` removes class), specify `opposite: true`.
 
 ```js
 'model.isAwesome': {
@@ -97,6 +97,8 @@ toggles whole attribute on the element (think `checked`) based on boolean interp
     // or a yes/no case
     yes: 'data-is-awesome',
     no: 'data-is-not-awesome'
+    // if you need opposite interpretation
+    opposite: true
 }
 ```
 
@@ -305,7 +307,7 @@ module.exports = View.extend({
 
 ## other benefits
 
-Previously after having given views the ability to have their own properties (since view inherits from state) it was awkward to bind those to the DOM. Also, for binding things that were not just `this.model` the syntax had to change. 
+Previously after having given views the ability to have their own properties (since view inherits from state) it was awkward to bind those to the DOM. Also, for binding things that were not just `this.model` the syntax had to change.
 
 Now this is fairly simple/obvious:
 

--- a/ampersand-dom-bindings.js
+++ b/ampersand-dom-bindings.js
@@ -126,6 +126,8 @@ function getBindingFunc(binding, context) {
         } else {
             return function (el, value, keyName) {
                 var name = makeArray(binding.name || keyName);
+                var opposite = (binding.opposite || false);
+                value = (opposite ? (value ? false : true) : value);
                 getMatches(el, selector).forEach(function (match) {
                     name.forEach(function (className) {
                         dom[value ? 'addClass' : 'removeClass'](match, className);
@@ -157,6 +159,8 @@ function getBindingFunc(binding, context) {
         } else {
             return function (el, value, keyName) {
                 var name = makeArray(binding.name || keyName);
+                var opposite = (binding.opposite || false);
+                value = (opposite ? (value ? false : true) : value);
                 getMatches(el, selector).forEach(function (match) {
                     name.forEach(function (attr) {
                         dom[value ? 'addAttribute' : 'removeAttribute'](match, attr);

--- a/ampersand-dom-bindings.js
+++ b/ampersand-dom-bindings.js
@@ -126,8 +126,8 @@ function getBindingFunc(binding, context) {
         } else {
             return function (el, value, keyName) {
                 var name = makeArray(binding.name || keyName);
-                var opposite = (binding.opposite || false);
-                value = (opposite ? (value ? false : true) : value);
+                var invert = (binding.invert || false);
+                value = (invert ? (value ? false : true) : value);
                 getMatches(el, selector).forEach(function (match) {
                     name.forEach(function (className) {
                         dom[value ? 'addClass' : 'removeClass'](match, className);
@@ -159,8 +159,8 @@ function getBindingFunc(binding, context) {
         } else {
             return function (el, value, keyName) {
                 var name = makeArray(binding.name || keyName);
-                var opposite = (binding.opposite || false);
-                value = (opposite ? (value ? false : true) : value);
+                var invert = (binding.invert || false);
+                value = (invert ? (value ? false : true) : value);
                 getMatches(el, selector).forEach(function (match) {
                     name.forEach(function (attr) {
                         dom[value ? 'addAttribute' : 'removeAttribute'](match, attr);
@@ -170,7 +170,7 @@ function getBindingFunc(binding, context) {
         }
     } else if (type === 'toggle') {
         var mode = (binding.mode || 'display');
-        var opposite = (binding.opposite || false);
+        var invert = (binding.invert || false);
         // this doesn't require a selector since we can pass yes/no selectors
         if (hasYesNo) {
             return function (el, value) {
@@ -183,7 +183,7 @@ function getBindingFunc(binding, context) {
             };
         } else {
             return function (el, value) {
-                value = (opposite ? (value ? false : true) : value);
+                value = (invert ? (value ? false : true) : value);
                 getMatches(el, selector).forEach(function (match) {
                     dom[value ? 'show' : 'hide'](match, mode);
                 });

--- a/ampersand-dom-bindings.js
+++ b/ampersand-dom-bindings.js
@@ -166,6 +166,7 @@ function getBindingFunc(binding, context) {
         }
     } else if (type === 'toggle') {
         var mode = (binding.mode || 'display');
+        var opposite = (binding.opposite || false);
         // this doesn't require a selector since we can pass yes/no selectors
         if (hasYesNo) {
             return function (el, value) {
@@ -178,6 +179,7 @@ function getBindingFunc(binding, context) {
             };
         } else {
             return function (el, value) {
+                value = (opposite ? (value ? false : true) : value);
                 getMatches(el, selector).forEach(function (match) {
                     dom[value ? 'show' : 'hide'](match, mode);
                 });

--- a/test/index.js
+++ b/test/index.js
@@ -729,10 +729,10 @@ test('toggle with opposite interpretation', function (t) {
     t.equal(span.style.display, '', 'base case');
 
     bindings.run('model1', null, el, true);
-    t.equal(span.style.display, '', 'should now be hidden');
+    t.equal(span.style.display, 'none', 'should now be hidden');
 
-    bindings.run('model1', null, el, true);
-    t.equal(span.style.display, 'none', 'should now be visible');
+    bindings.run('model1', null, el, false);
+    t.equal(span.style.display, '', 'should now be visible');
 
     t.end();
 });

--- a/test/index.js
+++ b/test/index.js
@@ -712,6 +712,31 @@ test('basic toggle', function (t) {
     t.end();
 });
 
+test('toggle with opposite interpretation', function (t) {
+    var el = getEl('<span></span>');
+    var bindings = domBindings({
+        'model1': {
+            type: 'toggle',
+            opposite: true,
+            selector: 'span'
+        }
+    });
+
+    var span = el.children[0];
+    t.equal(span.style.display, '', 'base case');
+
+    bindings.run('model1', null, el, false);
+    t.equal(span.style.display, '', 'base case');
+
+    bindings.run('model1', null, el, true);
+    t.equal(span.style.display, '', 'should now be hidden');
+
+    bindings.run('model1', null, el, true);
+    t.equal(span.style.display, 'none', 'should now be visible');
+
+    t.end();
+});
+
 test('toggle visibility property', function (t) {
     var el = getEl('<span></span>');
     var bindings = domBindings({

--- a/test/index.js
+++ b/test/index.js
@@ -171,6 +171,8 @@ add/removes class based on boolean interpretation of property name.
     // or a yes/no case
     yes: 'active',
     no: 'not-active'
+    // if you need opposite interpretation
+    opposite: true
 }
 ```
 */
@@ -190,6 +192,28 @@ test('booleanClass bindings', function (t) {
 
     t.ok(dom.hasClass(el.firstChild, 'awesome'));
     bindings.run('', null, el, false);
+
+    t.notOk(dom.hasClass(el.firstChild, 'awesome'));
+
+    t.end();
+});
+
+test('booleanClass bindings opposite interpretation', function (t) {
+    var el = getEl('<input type="checkbox" class="thing" data-hook="some-hook">');
+    var bindings = domBindings({
+        'model': {
+            type: 'booleanClass',
+            selector: '.thing',
+            opposite: true,
+            name: 'awesome'
+        }
+    });
+
+    t.notOk(dom.hasClass(el.firstChild, 'awesome'));
+    bindings.run('', null, el, false);
+
+    t.ok(dom.hasClass(el.firstChild, 'awesome'));
+    bindings.run('', null, el, true);
 
     t.notOk(dom.hasClass(el.firstChild, 'awesome'));
 
@@ -239,6 +263,31 @@ test('booleanClass array bindings', function (t) {
     t.ok(dom.hasClass(el.firstChild, 'class2'));
 
     bindings.run('', null, el, false);
+    t.notOk(dom.hasClass(el.firstChild, 'class1'));
+    t.notOk(dom.hasClass(el.firstChild, 'class2'));
+
+    t.end();
+});
+
+test('booleanClass array bindings opposite interpretation', function (t) {
+    var el = getEl('<input type="checkbox" class="thing" data-hook="some-hook">');
+    var bindings = domBindings({
+        'model': {
+            type: 'booleanClass',
+            selector: '.thing',
+            opposite: true,
+            name: ['class1', 'class2']
+        }
+    });
+
+    t.notOk(dom.hasClass(el.firstChild, 'class1'));
+    t.notOk(dom.hasClass(el.firstChild, 'class2'));
+
+    bindings.run('', null, el, false);
+    t.ok(dom.hasClass(el.firstChild, 'class1'));
+    t.ok(dom.hasClass(el.firstChild, 'class2'));
+
+    bindings.run('', null, el, true);
     t.notOk(dom.hasClass(el.firstChild, 'class1'));
     t.notOk(dom.hasClass(el.firstChild, 'class2'));
 
@@ -340,6 +389,31 @@ test('booleanAttribute array bindings', function (t) {
     t.ok(el.firstChild.readOnly, 'should readOnly');
 
     bindings.run('', null, el, false, 'disabled, readOnly');
+    t.notOk(el.firstChild.disabled, 'should not be disabled');
+    t.notOk(el.firstChild.readOnly, 'should not be readOnly');
+
+    t.end();
+});
+
+test('booleanAttribute array bindings opposite interpretation', function (t) {
+    var el = getEl('<input type="checkbox" class="thing" data-hook="some-hook">');
+    var bindings = domBindings({
+        'model': {
+            type: 'booleanAttribute',
+            selector: '.thing',
+            opposite: true,
+            name: ['disabled', 'readOnly']
+        }
+    });
+
+    t.notOk(el.firstChild.disabled, 'should not be disabled to start');
+    t.notOk(el.firstChild.readOnly, 'should not be readOnly to start');
+
+    bindings.run('', null, el, false, 'disabled, readOnly');
+    t.ok(el.firstChild.disabled, 'should disabled');
+    t.ok(el.firstChild.readOnly, 'should readOnly');
+
+    bindings.run('', null, el, true, 'disabled, readOnly');
     t.notOk(el.firstChild.disabled, 'should not be disabled');
     t.notOk(el.firstChild.readOnly, 'should not be readOnly');
 

--- a/test/index.js
+++ b/test/index.js
@@ -300,6 +300,28 @@ test('booleanAttribute bindings', function (t) {
     t.end();
 });
 
+test('booleanAttribute bindings opposite interpretation', function (t) {
+    var el = getEl('<input type="checkbox" class="thing" data-hook="some-hook">');
+    var bindings = domBindings({
+        'model': {
+            type: 'booleanAttribute',
+            selector: '.thing',
+            opposite: true,
+            name: 'checked'
+        }
+    });
+
+    t.notOk(el.firstChild.checked, 'should not be checked to start');
+
+    bindings.run('', null, el, false, 'checked');
+    t.ok(el.firstChild.checked, 'should checked');
+
+    bindings.run('', null, el, true, 'checked');
+    t.notOk(el.firstChild.checked, 'should not be checked');
+
+    t.end();
+});
+
 test('booleanAttribute array bindings', function (t) {
     var el = getEl('<input type="checkbox" class="thing" data-hook="some-hook">');
     var bindings = domBindings({

--- a/test/index.js
+++ b/test/index.js
@@ -171,8 +171,8 @@ add/removes class based on boolean interpretation of property name.
     // or a yes/no case
     yes: 'active',
     no: 'not-active'
-    // if you need opposite interpretation
-    opposite: true
+    // if you need inverse interpretation
+    invert: true
 }
 ```
 */
@@ -198,13 +198,13 @@ test('booleanClass bindings', function (t) {
     t.end();
 });
 
-test('booleanClass bindings opposite interpretation', function (t) {
+test('booleanClass bindings inverse interpretation', function (t) {
     var el = getEl('<input type="checkbox" class="thing" data-hook="some-hook">');
     var bindings = domBindings({
         'model': {
             type: 'booleanClass',
             selector: '.thing',
-            opposite: true,
+            invert: true,
             name: 'awesome'
         }
     });
@@ -269,13 +269,13 @@ test('booleanClass array bindings', function (t) {
     t.end();
 });
 
-test('booleanClass array bindings opposite interpretation', function (t) {
+test('booleanClass array bindings inverse interpretation', function (t) {
     var el = getEl('<input type="checkbox" class="thing" data-hook="some-hook">');
     var bindings = domBindings({
         'model': {
             type: 'booleanClass',
             selector: '.thing',
-            opposite: true,
+            invert: true,
             name: ['class1', 'class2']
         }
     });
@@ -349,13 +349,13 @@ test('booleanAttribute bindings', function (t) {
     t.end();
 });
 
-test('booleanAttribute bindings opposite interpretation', function (t) {
+test('booleanAttribute bindings inverse interpretation', function (t) {
     var el = getEl('<input type="checkbox" class="thing" data-hook="some-hook">');
     var bindings = domBindings({
         'model': {
             type: 'booleanAttribute',
             selector: '.thing',
-            opposite: true,
+            invert: true,
             name: 'checked'
         }
     });
@@ -395,13 +395,13 @@ test('booleanAttribute array bindings', function (t) {
     t.end();
 });
 
-test('booleanAttribute array bindings opposite interpretation', function (t) {
+test('booleanAttribute array bindings inverse interpretation', function (t) {
     var el = getEl('<input type="checkbox" class="thing" data-hook="some-hook">');
     var bindings = domBindings({
         'model': {
             type: 'booleanAttribute',
             selector: '.thing',
-            opposite: true,
+            invert: true,
             name: ['disabled', 'readOnly']
         }
     });
@@ -808,12 +808,12 @@ test('basic toggle', function (t) {
     t.end();
 });
 
-test('toggle with opposite interpretation', function (t) {
+test('toggle with inverse interpretation', function (t) {
     var el = getEl('<span></span>');
     var bindings = domBindings({
         'model1': {
             type: 'toggle',
-            opposite: true,
+            invert: true,
             selector: 'span'
         }
     });


### PR DESCRIPTION
I often find the need to use the 'toggle' binding but find myself needing the opposite effect. So, for instance, if I have a binding like this:

```javascript
'model.comments.length': {
    type: 'toggle',
    hook: 'no-comments-msg'
}
```

It would be great if I could expect the boolean interpretation of the value to have the opposite effect on the visibility of the element represented by the hook/selector. In other words, in this case, when there are no comments (array is length 0), I want to _show_ a message.

I added a new property to the `ampersand-dom-bindings` **toggle** type called `opposite` that will allow the value of the element to be interpreted in its negated form. So, if the value is usually interpreted to be true, it will now be false and vice versa.

**Example:**

```javascript
'model.comments.length': {
    type: 'toggle',
    opposite: true,
    hook: 'no-comments-msg'
}
```

It's a pretty simple change overall that will add a lot of convenience. Before this, I've had to create derived properties in my models like 'has_no_comments' just to have this effect.

-Kyle