### PR TITLE
Option to bind to first matched selector only

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,34 @@ module.exports = View.extend({
 });
 ```
 
+## firstMatchOnly
+
+As an option you can add `firstMatchOnly: true` to the binding declaration. It will cause
+the selector matcher to grab only the first match.
+
+Useful for cases when a view renders a collection with several elements with the same
+class/data-hook.
+
+```js
+module.exports = View.extend({
+  template: '<div><span data-hook="foo"></span><span data-hook="foo"></span>',
+  props: {
+    someText: 'string'
+  },
+  initialize: function(){
+    this.someText = 'hello';
+  },
+  bindings: {
+    'someText': {
+      type: 'text',
+      hook: 'foo',
+      firstMatchOnly: true
+    }
+  }
+});
+// will render <div><span data-hook="foo">hello</span><span data-hook="foo"></span></div>
+```
+
 ## changelog
 
 - 3.3.1 - Fix issues with yes/no handling in boolean class. Add lots of tests.

--- a/ampersand-dom-bindings.js
+++ b/ampersand-dom-bindings.js
@@ -11,8 +11,7 @@ function getMatches(el, selector, firstOnly) {
     if(!selector) return matches;
     if(firstOnly) {
         if (matchesSelector(el, selector)) return [el];
-        // return el.querySelector(selector) ? [el.querySelector(selector)] : [];
-        return matches.concat(slice.call([el.querySelector(selector) || el]));
+        return el.querySelector(selector) ? [el.querySelector(selector)] : [];
     }else{
         if (matchesSelector(el, selector)) matches.push(el);
         return matches.concat(slice.call(el.querySelectorAll(selector)));

--- a/ampersand-dom-bindings.js
+++ b/ampersand-dom-bindings.js
@@ -8,10 +8,16 @@ var slice = Array.prototype.slice;
 function getMatches(el, selector) {
     if (selector === '') return [el];
     var matches = [];
-    if (matchesSelector(el, selector)) matches.push(el);
-    return matches.concat(slice.call(el.querySelectorAll(selector)));
+    if(!selector) return matches;
+    if(selector.firstMatchOnly) {
+        //interactar modification to retrieve only firstMatchOnly element
+        if (matchesSelector(el, selector.firstMatchOnly)) return [el];
+        return matches.concat(slice.call([el.querySelector(selector.firstMatchOnly) || el]));
+    }else{
+        if (matchesSelector(el, selector)) matches.push(el);
+        return matches.concat(slice.call(el.querySelectorAll(selector)));
+    }
 }
-
 function setAttributes(el, attrs) {
     for (var name in attrs) {
         dom.setAttribute(el, name, attrs[name]);
@@ -46,12 +52,22 @@ function switchHandler(binding, el, value) {
 }
 
 function getSelector(binding) {
-    if (typeof binding.selector === 'string') {
-        return binding.selector;
-    } else if (binding.hook) {
-        return '[data-hook~="' + binding.hook + '"]';
-    } else {
-        return '';
+    if(binding.firstMatchOnly !== undefined && binding.firstMatchOnly === true) {
+        if (typeof binding.selector === 'string') {
+            return {firstMatchOnly:binding.selector};
+        } else if (binding.hook) {
+            return {firstMatchOnly:'[data-hook~="' + binding.hook + '"]'};
+        } else {
+            return {firstMatchOnly:''};
+        }
+    }else{
+        if (typeof binding.selector === 'string') {
+          return binding.selector;
+        } else if (binding.hook) {
+          return '[data-hook~="' + binding.hook + '"]';
+        } else {
+          return '';
+        }
     }
 }
 

--- a/ampersand-dom-bindings.js
+++ b/ampersand-dom-bindings.js
@@ -9,7 +9,7 @@ function getMatches(el, selector, firstOnly) {
     if (selector === '') return [el];
     var matches = [];
     if (!selector) return matches;
-    if( firstOnly) {
+    if (firstOnly) {
         if (matchesSelector(el, selector)) return [el];
         return el.querySelector(selector) ? [el.querySelector(selector)] : [];
     } else {

--- a/ampersand-dom-bindings.js
+++ b/ampersand-dom-bindings.js
@@ -8,11 +8,11 @@ var slice = Array.prototype.slice;
 function getMatches(el, selector, firstOnly) {
     if (selector === '') return [el];
     var matches = [];
-    if(!selector) return matches;
-    if(firstOnly) {
+    if (!selector) return matches;
+    if( firstOnly) {
         if (matchesSelector(el, selector)) return [el];
         return el.querySelector(selector) ? [el.querySelector(selector)] : [];
-    }else{
+    } else {
         if (matchesSelector(el, selector)) matches.push(el);
         return matches.concat(slice.call(el.querySelectorAll(selector)));
     }

--- a/ampersand-dom-bindings.js
+++ b/ampersand-dom-bindings.js
@@ -36,16 +36,20 @@ function makeArray(val) {
 function switchHandler(binding, el, value) {
     // the element selector to show
     var showValue = binding.cases[value];
+
+    var firstMatchOnly = binding.firstMatchOnly;
+
     // hide all the other elements with a different value
     for (var item in binding.cases) {
         var curValue = binding.cases[item];
+
         if (value !== item && curValue !== showValue) {
-            getMatches(el, curValue, binding.firstMatchOnly).forEach(function (match) {
+            getMatches(el, curValue, firstMatchOnly).forEach(function (match) {
                 dom.hide(match);
             });
         }
     }
-    getMatches(el, showValue).forEach(function (match) {
+    getMatches(el, showValue, firstMatchOnly).forEach(function (match) {
         dom.show(match);
     });
 }

--- a/ampersand-dom-bindings.js
+++ b/ampersand-dom-bindings.js
@@ -11,6 +11,7 @@ function getMatches(el, selector, firstOnly) {
     if(!selector) return matches;
     if(firstOnly) {
         if (matchesSelector(el, selector)) return [el];
+        // return el.querySelector(selector) ? [el.querySelector(selector)] : [];
         return matches.concat(slice.call([el.querySelector(selector) || el]));
     }else{
         if (matchesSelector(el, selector)) matches.push(el);

--- a/test/index.js
+++ b/test/index.js
@@ -1192,3 +1192,58 @@ test('firstMatchOnly option should work on the first occurrence', function(t){
     t.notEqual(child1.textContent, 'hello');
     t.end();
 });
+
+test('firstMatchOnly option should work on a type switch cases', function (t) {
+    var el = getEl('<div class="foo"></div><div class="bar"></div><div class="bar"></div><div class="baz"></div>');
+    var bindings = domBindings({
+        'model': {
+            type: 'switch',
+            firstMatchOnly: true,
+            cases: {
+                foo: '.foo',
+                bar: '.bar',
+                baz: '.baz'
+            }
+        }
+    });
+
+    var foo = el.children[0];
+    var bar = el.children[1];
+    var barDupe = el.children[2]; // dupe .bar
+    var baz = el.children[3];
+
+    t.equal(foo.style.display, '', 'case .foo display should be empty (visible)');
+    t.equal(bar.style.display, '', 'case .bar, first match, display should be empty (visible)');
+    t.equal(barDupe.style.display, '', 'case .bar, second match, display should be empty (visible)');
+    t.equal(baz.style.display, '', 'case .baz display should be empty (visible)');
+
+    bindings.run('', null, el, 'foo');
+
+    t.equal(foo.style.display, '', 'case .foo display should be empty (visible)');
+    t.equal(bar.style.display, 'none', 'case .bar, first match, display should be "none"');
+    t.equal(barDupe.style.display, '', 'case .bar, second match, should remain empty (visible)');
+    t.equal(baz.style.display, 'none', 'case .baz display shuld be "none"');
+
+    bindings.run('', null, el, 'bar');
+
+    t.equal(foo.style.display, 'none', 'case .foo display should be "none"');
+    t.equal(bar.style.display, '', 'case .bar, first match, display should be empty (visible)');
+    t.equal(barDupe.style.display, '', 'case .bar, second match, should remain empty (visible)');
+    t.equal(baz.style.display, 'none', 'case .baz display shuld be "none"');
+
+    bindings.run('', null, el, 'baz');
+
+    t.equal(foo.style.display, 'none', 'case .foo display should be "none"');
+    t.equal(bar.style.display, 'none', 'case .bar, first match, display should be "none"');
+    t.equal(barDupe.style.display, '', 'case .bar, second match, should remain empty (visible)');
+    t.equal(baz.style.display, '', 'case .baz display should be empty (visible)');
+
+    bindings.run('', null, el, 'something else');
+
+    t.equal(foo.style.display, 'none', 'case .foo display should be "none"');
+    t.equal(bar.style.display, 'none', 'case .bar, first match, display should be "none"');
+    t.equal(barDupe.style.display, '', 'case .bar, second match, should remain empty (visible)');
+    t.equal(baz.style.display, 'none', 'case .baz display shuld be "none"');
+
+    t.end();
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1173,3 +1173,22 @@ test('handle yes/no cases for `toggle` when missing `yes` or `no`', function (t)
 
     t.end();
 });
+
+test('firstMatchOnly option should work on the first occurrence', function(t){
+    var el = getEl('<span data-hook="foo"></span><span data-hook="foo"></span>');
+    var bindings = domBindings({
+        'model': {
+            type: 'text',
+            hook: 'foo',
+            firstMatchOnly: true
+        }
+    });
+
+    var child0 = el.children[0];
+    var child1 = el.children[1];
+    // t.notEqual(el.firstChild.textContent, 'hello');
+    bindings.run('model', null, el, 'hello');
+    t.equal(child0.textContent, 'hello');
+    t.notEqual(child1.textContent, 'hello');
+    t.end();
+});


### PR DESCRIPTION
On one of my projects I needed to render a collection recursively and the bindings were messing all along the DOMNodes, so adding this option allowed me to use the binding on the first matched selector/hook, hence when the renderCollection took place the bindings were assigned properly.

Imagine a threaded view, each thread can have replies which have exactly the same options as the main thread: expand replies, reply, like, etc.

```js
ThreadView = View.extend({
  template: '<div><div class="reply-count"></div><div data-hook="replies-container"></div></div>',
  initialize: function(){
    this.replies = getRepliesSomeHow();
    this.replyCount = this.replies.length;
  },
  props: {
    replyCount: 'number'
  },
  bindings: {
    replyCount: {
      type: 'text',
      selector: '.reply-count',
      firstMatchOnly: true // without this line, the last rendered view filled every .reply-count
    }
  },
  render: function(){
    this.renderCollection(
      this.replies,
      ReplyView,
      this.queryByHook('replies-container')
    );
  }
});
ReplyView = View.extend({
  template: '<div data-hook="comment-container"></div>',
  render: function(){
    this.renderSubview(
      new ThreadView({model: this.model}),
      this.queryByHook('comment-container')
    );
  }
});
```

I'll leave it to you if this is worth merging, saved my life though.