### PR TITLE
Update deps

### DIFF
--- a/ampersand-dom-bindings.js
+++ b/ampersand-dom-bindings.js
@@ -2,7 +2,7 @@
 var Store = require('key-tree-store');
 var dom = require('ampersand-dom');
 var matchesSelector = require('matches-selector');
-var partial = require('lodash.partial');
+var partial = require('lodash/partial');
 var slice = Array.prototype.slice;
 
 function getMatches(el, selector, firstOnly) {

--- a/package.json
+++ b/package.json
@@ -16,18 +16,18 @@
     "ampersand-dom": "^1.2.5",
     "ampersand-version": "^1.0.0",
     "key-tree-store": "^1.2.0",
-    "lodash.partial": "^3.1.1",
+    "lodash": "^4.17.4",
     "matches-selector": "^1.0.0"
   },
   "devDependencies": {
-    "browserify": "^11.0.0",
+    "browserify": "^13.3.0",
     "jshint": "^2.5.6",
-    "phantomjs": "^1.9.7-15",
+    "phantomjs": "^2.1.7",
     "precommit-hook": "^3.0.0",
     "run-browser": "^2.0.2",
     "tap-spec": "^4.0.2",
     "tape": "^4.0.0",
-    "tape-run": "^1.0.0"
+    "tape-run": "^2.1.5"
   },
   "keywords": [
     "dom",


### PR DESCRIPTION
Update deps and devDeps. Notably, replacing lodash.partial (v3) with lodash/partial (v4).

This brings this module inline with the other ampersand modules that have long since updated to lodash@4. This was including an extra 21kb in my build when ampersand-dom-bindings was required by ampersand-view.

I can't remember what the policy is, but I recommend a patch/minor version bump, since there are no breaking changes; on the contrary, it will be a backwards-compatible improvement, as it will shrink many ampersand-view installs/bundles.