### PR TITLE
Lets not include all of lodash for this module

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ampersand-dom": "^1.2.5",
     "ampersand-version": "^1.0.0",
     "key-tree-store": "^1.2.0",
-    "lodash": "^4.17.4",
+    "lodash.partial": "^4.2.1",
     "matches-selector": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This can lead to client-side module pollution if the app depends on lodash@3 for some reason as this would then force all of lodash@4 to be installed under this module.