### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 
+node_js:
+  - "4"
+
 sudo: false
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: node_js
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.node-gyp
+    - $HOME/.npm
+    - node_modules
+
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"


### PR DESCRIPTION
Testing ground to update travis config to allow our tests to pass.

The latest versions of our deps (or deps of deps) use newer nodejs features (`const`, for example) and cause our tests to fail